### PR TITLE
Include Trailing "\n" When Updating Docker Images File

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,9 @@ runs:
   steps:
     - name: Check Inputs
       run: |
-        set -euo pipefail
+        # step: Check Inputs
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
         # DELETION MODE
         if [[ -n "${{ inputs.delete_image_tags }}" ]]; then
           if [[ -z "${{ inputs.dest_dir }}" || -n "${{ inputs.docker_tags }}" ]]; then
@@ -50,7 +52,8 @@ runs:
 
     - name: Git config
       run: |
-        set -euo pipefail
+        # step: Git config
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         git config user.name github-actions
         git config user.email github-actions@github.com
       shell: bash
@@ -58,7 +61,9 @@ runs:
     - name: Request Build(s) on CVMFS
       if: inputs.delete_image_tags == ''
       run: |
-        set -euo pipefail
+        # step: Request Build(s) on CVMFS
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
         # figure REMOVE_DOCKER_REPO (--remove-docker-repo)
         if [[ "${{ inputs.include_docker_repo }}" == "true" ]]; then
           REMOVE_DOCKER_REPO=''
@@ -83,7 +88,9 @@ runs:
     - name: Request Removal(s) on CVMFS
       if: inputs.delete_image_tags != ''
       run: |
-        set -euo pipefail
+        # step: Request Removal(s) on CVMFS
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
         python3 ${{ github.action_path }}/request_removal.py \
             --dest-dir "${{ inputs.dest_dir }}" \
             --delete-image-tags "${{ inputs.delete_image_tags }}"
@@ -94,7 +101,9 @@ runs:
 
     - name: Push changes
       run: |
-        set -euo pipefail
+        # step: Push changes
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
         status=`git status 2>&1 | tee`
         ahead=`echo -n "${status}" | grep "Your branch is ahead of" &> /dev/null; echo "$?"`
         if [ "$ahead" -eq "1" ]; then

--- a/request_build.py
+++ b/request_build.py
@@ -10,7 +10,7 @@ DOCKER_IMAGES_FILE = "./docker_images.txt"
 def main() -> None:
     """Main."""
     parser = argparse.ArgumentParser(
-        description=(f"Update {DOCKER_IMAGES_FILE}"),
+        description=f"Update {DOCKER_IMAGES_FILE}",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -48,8 +48,9 @@ def main() -> None:
 
     # read
     with open(DOCKER_IMAGES_FILE, "r") as f:
-        lines = [ln.strip() for ln in f.readlines()]  # rm each trailing '\n'
-        # remove all instances of the line
+        lines = [ln.strip() for ln in f.readlines()]  # remove each trailing '\n'
+        lines = [ln for ln in lines if ln]  # remove empty lines
+        # remove all variations of `cvmfs_image_str`
         lines = [
             ln for ln in lines if ln not in [cvmfs_image_str, f"-{cvmfs_image_str}"]
         ]
@@ -60,7 +61,8 @@ def main() -> None:
 
     # write
     with open(DOCKER_IMAGES_FILE, "w") as f:
-        f.write("\n".join(lines))
+        for ln in lines:
+            f.write(ln + "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, updates would change the last line _and_ penultimate line since it didn't previously have a trailing newline. This caused a misleading git history (file blaming).