### PR TITLE
Remove `include_docker_repo` [major]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
         # step: View changes
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
-        git show --stat
+        git log origin/main..HEAD --patch --reverse
 
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,25 @@ runs:
         # step: Check Inputs
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
-        # DELETION MODE
+        # UNSUPPORTED INPUT
+        if [[ -n "${{ inputs.include_docker_repo }}" ]]; then
+          echo "::error::Input Error: 'include_docker_repo' has been deprecated -- rely solely on 'dest_dir'."
+          exit 1
+        fi
+        
+        # REQUIRED INPUT
+        if [[ -z "${{ inputs.dest_dir }}" ]]; then
+          echo "::error::Input Error: 'dest_dir' is required."
+          exit 1
+        fi
+        
+        # DELETION MODE?
         if [[ -n "${{ inputs.delete_image_tags }}" ]]; then
-          if [[ -z "${{ inputs.dest_dir }}" || -n "${{ inputs.docker_tags }}" ]]; then
-            echo "::error::Input Error: 'delete_image_tags' requires 'dest_dir' and forbids 'docker_tags'."
+          if [[ -n "${{ inputs.docker_tags }}" ]]; then
+            echo "::error::Input Error: 'delete_image_tags' forbids 'docker_tags'."
             exit 1
           fi
-        # CREATION MODE
+        # CREATION MODE?
         elif [[ -z "${{ inputs.docker_tags }}" ]]; then
           echo "::error::Input Error: 'docker_tags' is required for build mode."
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
           echo "$IMAGE"
           echo "##[group]updating $DOCKER_IMAGES_FILE"
           python3 ${{ github.action_path }}/request_build.py \
-              --image-nametag "$IMAGE" \
+              --image-uri "$IMAGE" \
               --dest-dir ${{ inputs.dest_dir }}
           echo "##[endgroup]"
           git add "$DOCKER_IMAGES_FILE" || true

--- a/action.yml
+++ b/action.yml
@@ -101,10 +101,9 @@ runs:
           python3 ${{ github.action_path }}/request_removal.py \
             --dest-dir "${{ inputs.dest_dir }}" \
             --image-tag-pattern "$TAG"
+          git add "$DOCKER_IMAGES_FILE" || true
+          git commit -m "<bot> remove: $TAG" || true
         done
-        
-        git add "$DOCKER_IMAGES_FILE" || true
-        git commit -m "<bot> remove: ${DELETE_TAGS[*]}" || true
 
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,14 @@ inputs:
     required: true
   docker_tags:
     description: 'the list of Docker image tags requested to be built on CVMFS'  # use `${{ needs.docker.outputs.tags }}`
-    type: string
     default: ''
   delete_image_tags:
-    description: 'DELETION MODE: Image tag to match (full tag or prefix for SHA matching)'
+    description: |
+      DELETION MODE: Newline-delimited image tags to remove (as literal names or known patterns).
+      Example:
+        delete_image_tags: |
+          v1.2.3
+          main-[SHA]
     default: ''
 
 runs:
@@ -79,12 +83,19 @@ runs:
         # step: Request Removal(s) on CVMFS
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
-        python3 ${{ github.action_path }}/request_removal.py \
+        # load into array (w/ trimming)
+        mapfile -t DELETE_TAGS < <(printf '%s\n' "${{ inputs.delete_image_tags }}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')
+        
+        # request all matches for each tag (pattern)
+        for TAG in "${DELETE_TAGS[@]}"; do
+          echo "Removing tag: $TAG"
+          python3 ${{ github.action_path }}/request_removal.py \
             --dest-dir "${{ inputs.dest_dir }}" \
-            --image-tag-pattern "${{ inputs.delete_image_tags }}"
+            --image-tag-pattern "$TAG"
+        done
         
         git add docker_images.txt || true
-        git commit -m "<bot> remove: ${{ inputs.delete_image_tags }}" || true
+        git commit -m "<bot> remove: ${DELETE_TAGS[*]}" || true
 
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -87,15 +87,15 @@ runs:
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
         # update and commit for each tag
-        for TAG in "${{ inputs.docker_tags }}"; do
-          echo $TAG
+        for IMAGE in "${{ inputs.docker_tags }}"; do
+          echo "$IMAGE"
           echo "##[group]updating $DOCKER_IMAGES_FILE"
           python3 ${{ github.action_path }}/request_build.py \
-              --docker-tag $TAG \
+              --image-nametag "$IMAGE" \
               --dest-dir ${{ inputs.dest_dir }}
           echo "##[endgroup]"
           git add "$DOCKER_IMAGES_FILE" || true
-          git commit -m "<bot> build: $TAG" || true
+          git commit -m "<bot> build: $IMAGE" || true
         done
 
       shell: bash
@@ -107,18 +107,18 @@ runs:
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
         # load into array (w/ trimming)
-        mapfile -t DELETE_TAGS < <(printf '%s\n' "${{ inputs.delete_image_tags }}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')
+        mapfile -t DELETE_IMAGES < <(printf '%s\n' "${{ inputs.delete_image_tags }}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')
         
         # request all matches for each tag (pattern)
-        for TAG in "${DELETE_TAGS[@]}"; do
-          echo "Removing tag: $TAG"
+        for IMAGE in "${DELETE_IMAGES[@]}"; do
+          echo "$IMAGE"
           echo "##[group]updating $DOCKER_IMAGES_FILE"
           python3 ${{ github.action_path }}/request_removal.py \
             --dest-dir "${{ inputs.dest_dir }}" \
-            --image-tag-pattern "$TAG"
+            --image-nametag-pattern "$IMAGE"
           echo "##[endgroup]"
           git add "$DOCKER_IMAGES_FILE" || true
-          git commit -m "<bot> remove: $TAG" || true
+          git commit -m "<bot> remove: $IMAGE" || true
         done
 
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
         # step: View changes
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
-        git log origin/main..HEAD --patch --reverse
+        git diff --unified=0 origin/main...HEAD
 
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set Global Env Vars
+      run: |
+        # step: Set Global Env Vars
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
+        echo "DOCKER_IMAGES_FILE=./docker_images.txt" >> "$GITHUB_ENV"
+
+      shell: bash
+
     - name: Check Inputs
       run: |
         # step: Check Inputs
@@ -71,7 +80,7 @@ runs:
           python3 ${{ github.action_path }}/request_build.py \
               --docker-tag $TAG \
               --dest-dir ${{ inputs.dest_dir }}
-          git add docker_images.txt || true
+          git add "$DOCKER_IMAGES_FILE" || true
           git commit -m "<bot> build: $TAG" || true
         done
 
@@ -94,7 +103,7 @@ runs:
             --image-tag-pattern "$TAG"
         done
         
-        git add docker_images.txt || true
+        git add "$DOCKER_IMAGES_FILE" || true
         git commit -m "<bot> remove: ${DELETE_TAGS[*]}" || true
 
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -89,9 +89,11 @@ runs:
         # update and commit for each tag
         for TAG in "${{ inputs.docker_tags }}"; do
           echo $TAG
+          echo "##[group]updating $DOCKER_IMAGES_FILE"
           python3 ${{ github.action_path }}/request_build.py \
               --docker-tag $TAG \
               --dest-dir ${{ inputs.dest_dir }}
+          echo "##[endgroup]"
           git add "$DOCKER_IMAGES_FILE" || true
           git commit -m "<bot> build: $TAG" || true
         done
@@ -110,12 +112,23 @@ runs:
         # request all matches for each tag (pattern)
         for TAG in "${DELETE_TAGS[@]}"; do
           echo "Removing tag: $TAG"
+          echo "##[group]updating $DOCKER_IMAGES_FILE"
           python3 ${{ github.action_path }}/request_removal.py \
             --dest-dir "${{ inputs.dest_dir }}" \
             --image-tag-pattern "$TAG"
+          echo "##[endgroup]"
           git add "$DOCKER_IMAGES_FILE" || true
           git commit -m "<bot> remove: $TAG" || true
         done
+
+      shell: bash
+
+    - name: View changes
+      run: |
+        # step: View changes
+        set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
+        git show --stat
 
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
         
         python3 ${{ github.action_path }}/request_removal.py \
             --dest-dir "${{ inputs.dest_dir }}" \
-            --delete-image-tags "${{ inputs.delete_image_tags }}"
+            --image-tag-pattern "${{ inputs.delete_image_tags }}"
         
         git add docker_images.txt || true
         git commit -m "<bot> remove: ${{ inputs.delete_image_tags }}" || true

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,6 @@ inputs:
     description: 'the list of Docker image tags requested to be built on CVMFS'  # use `${{ needs.docker.outputs.tags }}`
     type: string
     default: ''
-  include_docker_repo:
-    description: 'whether to include the docker repo when inserting into CVMFS dir; e.g. icecube/skymap_scanner:3 -> DEST_DIR/skymap_scanner:3 OR DEST_DIR/icecube/skymap_scanner:3'
-    type: boolean  # the incoming type is boolean, but to access it's a string; e.i. 'true', 'false'
-    default: 'true'
   delete_image_tags:
     description: 'DELETION MODE: Image tag to match (full tag or prefix for SHA matching)'
     default: ''
@@ -65,23 +61,12 @@ runs:
         # step: Request Build(s) on CVMFS
         set -euo pipefail; echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
-        # figure REMOVE_DOCKER_REPO (--remove-docker-repo)
-        if [[ "${{ inputs.include_docker_repo }}" == "true" ]]; then
-          REMOVE_DOCKER_REPO=''
-        elif [[ "${{ inputs.include_docker_repo }}" == "false" ]]; then
-          REMOVE_DOCKER_REPO='--remove-docker-repo'
-        else
-          echo "ERROR: Unsupported input: 'include_docker_repo' (${{ inputs.include_docker_repo }})"
-          exit 1
-        fi
-        
         # update and commit for each tag
         for TAG in "${{ inputs.docker_tags }}"; do
           echo $TAG
           python3 ${{ github.action_path }}/request_build.py \
               --docker-tag $TAG \
-              --dest-dir ${{ inputs.dest_dir }} \
-              $REMOVE_DOCKER_REPO
+              --dest-dir ${{ inputs.dest_dir }}
           git add docker_images.txt || true
           git commit -m "<bot> build: $TAG" || true
         done

--- a/request_build.py
+++ b/request_build.py
@@ -1,16 +1,15 @@
-"""Update ./docker_images.txt with a build request."""
+"""Update the docker-images file with a build request."""
 
 import argparse
 import logging
+import os
 from pathlib import Path
-
-DOCKER_IMAGES_FILE = "./docker_images.txt"
 
 
 def main() -> None:
     """Main."""
     parser = argparse.ArgumentParser(
-        description=f"Update {DOCKER_IMAGES_FILE}",
+        description=f"Update {os.environ['DOCKER_IMAGES_FILE']} to build image(s)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -29,13 +28,13 @@ def main() -> None:
     for arg, val in vars(args).items():
         logging.warning(f"{arg}: {val}")
 
-    # assemble line for docker_images.txt
+    # assemble line for the docker-images file
     # TAG  = "icecube/skymap_scanner:3"
     # LINE = "docker://icecube/skymap_scanner:3 realtime/skymap_scanner:3"
     cvmfs_image_str = f"docker://{args.docker_tag} {args.dest_dir / args.docker_tag}"
 
     # read
-    with open(DOCKER_IMAGES_FILE, "r") as f:
+    with open(os.environ["DOCKER_IMAGES_FILE"], "r") as f:
         lines = [ln.strip() for ln in f.readlines()]  # remove each trailing '\n'
         lines = [ln for ln in lines if ln]  # remove empty lines
         # remove all variations of `cvmfs_image_str`
@@ -45,10 +44,10 @@ def main() -> None:
 
     # append
     lines.append(cvmfs_image_str)
-    logging.debug(f"Added line to {DOCKER_IMAGES_FILE}: {lines[-1]}")
+    logging.debug(f"Added line to {os.environ['DOCKER_IMAGES_FILE']}: {lines[-1]}")
 
     # write
-    with open(DOCKER_IMAGES_FILE, "w") as f:
+    with open(os.environ["DOCKER_IMAGES_FILE"], "w") as f:
         for ln in lines:
             f.write(ln + "\n")
 

--- a/request_build.py
+++ b/request_build.py
@@ -5,6 +5,8 @@ import logging
 import os
 from pathlib import Path
 
+from utils import valid_image_tag
+
 
 def main() -> None:
     """Main."""
@@ -15,6 +17,7 @@ def main() -> None:
     parser.add_argument(
         "--docker-tag",
         required=True,
+        type=valid_image_tag,
         help="The docker image tag",
     )
     parser.add_argument(

--- a/request_build.py
+++ b/request_build.py
@@ -5,7 +5,7 @@ import logging
 import os
 from pathlib import Path
 
-from utils import valid_image_nametag
+from utils import parse_image_uri
 
 
 def main() -> None:
@@ -15,10 +15,11 @@ def main() -> None:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        "--image-nametag",
+        "--image-uri",
+        dest="image",  # type is 'ImageParsed'
         required=True,
-        type=valid_image_nametag,
-        help="The docker image name w/ tag",
+        type=parse_image_uri,
+        help="The docker image uri w/ name and tag, eg: 'icecube/skymap_scanner:4.0.0', 'ghcr.io/wipacrepo/iceprod:3.0.52', ...",
     )
     parser.add_argument(
         "--dest-dir",
@@ -32,9 +33,7 @@ def main() -> None:
         logging.warning(f"{arg}: {val}")
 
     # assemble line for the docker-images file
-    # TAG  = "icecube/skymap_scanner:3"
-    # LINE = "docker://icecube/skymap_scanner:3 realtime/skymap_scanner:3"
-    cvmfs_image_str = f"docker://{args.docker_tag} {args.dest_dir / args.docker_tag}"
+    cvmfs_image_str = f"docker://{args.image.uri} {args.dest_dir / args.image.nametag}"
 
     # read
     with open(os.environ["DOCKER_IMAGES_FILE"], "r") as f:

--- a/request_build.py
+++ b/request_build.py
@@ -2,7 +2,7 @@
 
 import argparse
 import logging
-import os
+from pathlib import Path
 
 DOCKER_IMAGES_FILE = "./docker_images.txt"
 
@@ -20,31 +20,19 @@ def main() -> None:
     )
     parser.add_argument(
         "--dest-dir",
-        default="",
-        help="The destination directory, eg: realtime",
-    )
-    parser.add_argument(
-        "--remove-docker-repo",
-        default=False,
-        action="store_true",
-        help="whether to remove the docker image's repo when inserting to CVMFS dir",
+        required=True,
+        type=Path,
+        help="The destination directory, eg: 'realtime', 'ewms/observation-management-service', ...",
     )
 
     args = parser.parse_args()
     for arg, val in vars(args).items():
         logging.warning(f"{arg}: {val}")
 
+    # assemble line for docker_images.txt
     # TAG  = "icecube/skymap_scanner:3"
     # LINE = "docker://icecube/skymap_scanner:3 realtime/skymap_scanner:3"
-
-    if args.remove_docker_repo:
-        dest_file = args.docker_tag.split("/", maxsplit=1)[1]
-    else:
-        dest_file = args.docker_tag
-
-    cvmfs_image_str = (
-        f"docker://{args.docker_tag} {os.path.join(args.dest_dir,dest_file)}"
-    )
+    cvmfs_image_str = f"docker://{args.docker_tag} {args.dest_dir / args.docker_tag}"
 
     # read
     with open(DOCKER_IMAGES_FILE, "r") as f:

--- a/request_build.py
+++ b/request_build.py
@@ -5,7 +5,7 @@ import logging
 import os
 from pathlib import Path
 
-from utils import valid_image_tag
+from utils import valid_image_nametag
 
 
 def main() -> None:
@@ -15,10 +15,10 @@ def main() -> None:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        "--docker-tag",
+        "--image-nametag",
         required=True,
-        type=valid_image_tag,
-        help="The docker image tag",
+        type=valid_image_nametag,
+        help="The docker image name w/ tag",
     )
     parser.add_argument(
         "--dest-dir",

--- a/request_removal.py
+++ b/request_removal.py
@@ -85,7 +85,7 @@ def main() -> None:
         in_lines = [ln.strip() for ln in f.readlines()]  # Remove trailing '\n'
 
     # Modify lines that match the pattern
-    image_pattern = f"{args.dest_dir}/{args.image_tag_pattern}"
+    image_pattern = str(args.dest_dir / args.image_tag_pattern)
     out_lines = [
         f"-{ln}" if _matches_pattern(image_pattern, _get_image(ln)) else ln
         for ln in in_lines

--- a/request_removal.py
+++ b/request_removal.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import re
+from pathlib import Path
 
 DOCKER_IMAGES_FILE = "./docker_images.txt"
 
@@ -65,10 +66,11 @@ def main() -> None:
     parser.add_argument(
         "--dest-dir",
         required=True,
+        type=Path,
         help="CVMFS destination directory",
     )
     parser.add_argument(
-        "--delete-image-tags",
+        "--image-tag-pattern",
         required=True,
         help="Image tag to match (e.g., 'branch' for 'branch-[SHA]' or full tag for exact match)",
     )
@@ -81,7 +83,7 @@ def main() -> None:
         in_lines = [ln.strip() for ln in f.readlines()]  # Remove trailing '\n'
 
     # Modify lines that match the pattern
-    image_pattern = f"{args.dest_dir}/{args.delete_image_tags}"
+    image_pattern = f"{args.dest_dir}/{args.image_tag_pattern}"
     out_lines = [
         f"-{ln}" if _matches_pattern(image_pattern, _get_image(ln)) else ln
         for ln in in_lines

--- a/request_removal.py
+++ b/request_removal.py
@@ -6,27 +6,27 @@ import os
 import re
 from pathlib import Path
 
-from utils import valid_image_tag_pattern
+from utils import valid_image_nametag_pattern
 
 SHA_PATTERN = re.compile(r"^(?P<sha>[a-f0-9]+)$")
 SHA_TOKEN = "[SHA]"
 
 
-def _matches_pattern(image_pattern: str, image: str) -> bool:
+def _matches_pattern(full_image_pattern: str, image: str) -> bool:
     """Determine if a CVMFS image matches the given pattern w/ known tokens."""
 
-    if image_pattern.startswith("-"):  # this image has already been removed
+    if full_image_pattern.startswith("-"):  # this image has already been removed
         return False
 
     # [SHA] suffix
-    if image_pattern.endswith(SHA_TOKEN):
-        logging.debug(f"trying [SHA]-pattern: {image_pattern=} -> {image=}")
+    if full_image_pattern.endswith(SHA_TOKEN):
+        logging.debug(f"trying [SHA]-pattern: {full_image_pattern=} -> {image=}")
         # Example Matches:
         # "feature-branch-[SHA]" -> Matches "feature-branch-abc123"
         # "feature-branch-[SHA]" -> Does NOT match "feature-branch-xyz-abc123"
 
         # w/o SHA_TOKEN suffix (ex: feature-branch-)
-        base = image_pattern[: -len(SHA_TOKEN)]
+        base = full_image_pattern[: -len(SHA_TOKEN)]
         if not image.startswith(base):
             logging.debug(f"-> no match (does not start with {base=})")
             return False
@@ -45,8 +45,8 @@ def _matches_pattern(image_pattern: str, image: str) -> bool:
 
     # Exact match case
     else:
-        logging.debug(f"trying exact-name match: {image_pattern=} -> {image=}")
-        if image == image_pattern:
+        logging.debug(f"trying exact-name match: {full_image_pattern=} -> {image=}")
+        if image == full_image_pattern:
             logging.debug(f"-> matched!")
             return True
         else:
@@ -76,10 +76,10 @@ def main() -> None:
         help="CVMFS destination directory",
     )
     parser.add_argument(
-        "--image-tag-pattern",
+        "--image-nametag-pattern",
         required=True,
-        type=valid_image_tag_pattern,
-        help="Image tag to match (e.g., 'branch' for 'branch-[SHA]' or full tag for exact match)",
+        type=valid_image_nametag_pattern,
+        help="Image tag to match (ex: 'foo:branch-[SHA]', or full tag for exact match)",
     )
     args = parser.parse_args()
     for arg, val in vars(args).items():
@@ -90,9 +90,9 @@ def main() -> None:
         in_lines = [ln.strip() for ln in f.readlines()]  # Remove trailing '\n'
 
     # Modify lines that match the pattern
-    image_pattern = str(args.dest_dir / args.image_tag_pattern)
+    full_image_pattern = str(args.dest_dir / args.image_nametag_pattern)
     out_lines = [
-        f"-{ln}" if _matches_pattern(image_pattern, _get_image(ln)) else ln
+        f"-{ln}" if _matches_pattern(full_image_pattern, _get_image(ln)) else ln
         for ln in in_lines
     ]
 

--- a/request_removal.py
+++ b/request_removal.py
@@ -15,6 +15,9 @@ SHA_TOKEN = "[SHA]"
 def _matches_pattern(image_pattern: str, image: str) -> bool:
     """Determine if a CVMFS image matches the given pattern w/ known tokens."""
 
+    if image_pattern.startswith("-"):  # this image has already been removed
+        return False
+
     # [SHA] suffix
     if image_pattern.endswith(SHA_TOKEN):
         logging.debug(f"trying [SHA]-pattern: {image_pattern=} -> {image=}")
@@ -38,6 +41,8 @@ def _matches_pattern(image_pattern: str, image: str) -> bool:
             return False
 
     # FUTURE DEV: support additional string tokens
+    # elif...
+
     # Exact match case
     else:
         logging.debug(f"trying exact-name match: {image_pattern=} -> {image=}")

--- a/request_removal.py
+++ b/request_removal.py
@@ -6,6 +6,7 @@ import os
 import re
 from pathlib import Path
 
+from utils import valid_image_tag_pattern
 
 SHA_PATTERN = re.compile(r"^(?P<sha>[a-f0-9]+)$")
 SHA_TOKEN = "[SHA]"
@@ -72,6 +73,7 @@ def main() -> None:
     parser.add_argument(
         "--image-tag-pattern",
         required=True,
+        type=valid_image_tag_pattern,
         help="Image tag to match (e.g., 'branch' for 'branch-[SHA]' or full tag for exact match)",
     )
     args = parser.parse_args()

--- a/request_removal.py
+++ b/request_removal.py
@@ -1,11 +1,11 @@
-"""Update ./docker_images.txt with image removals based on image tag pattern and dest dir."""
+"""Update the docker-images file with image removals based on image tag pattern and dest dir."""
 
 import argparse
 import logging
+import os
 import re
 from pathlib import Path
 
-DOCKER_IMAGES_FILE = "./docker_images.txt"
 
 SHA_PATTERN = re.compile(r"^(?P<sha>[a-f0-9]+)$")
 SHA_TOKEN = "[SHA]"
@@ -60,7 +60,7 @@ def _get_image(line: str) -> str:
 def main() -> None:
     """Main."""
     parser = argparse.ArgumentParser(
-        description=(f"Update {DOCKER_IMAGES_FILE}"),
+        description=f"Update {os.environ['DOCKER_IMAGES_FILE']} to remove image(s)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -79,7 +79,7 @@ def main() -> None:
         logging.warning(f"{arg}: {val}")
 
     # read
-    with open(DOCKER_IMAGES_FILE, "r") as f:
+    with open(os.environ["DOCKER_IMAGES_FILE"], "r") as f:
         in_lines = [ln.strip() for ln in f.readlines()]  # Remove trailing '\n'
 
     # Modify lines that match the pattern
@@ -95,7 +95,7 @@ def main() -> None:
             logging.debug(f"Changed Line: {a} -> {b}")
 
     # write
-    with open(DOCKER_IMAGES_FILE, "w") as f:
+    with open(os.environ["DOCKER_IMAGES_FILE"], "w") as f:
         f.write("\n".join(out_lines) + "\n")
 
 

--- a/request_removal.py
+++ b/request_removal.py
@@ -12,27 +12,27 @@ SHA_PATTERN = re.compile(r"^(?P<sha>[a-f0-9]+)$")
 SHA_TOKEN = "[SHA]"
 
 
-def _matches_pattern(full_image_pattern: str, image: str) -> bool:
+def _matches_pattern(full_image_pattern: str, line: str) -> bool:
     """Determine if a CVMFS image matches the given pattern w/ known tokens."""
-
-    if full_image_pattern.startswith("-"):  # this image has already been removed
+    if line.startswith("-"):  # this image has already been removed
         return False
+    line_image = _get_line_image(line)
 
     # [SHA] suffix
     if full_image_pattern.endswith(SHA_TOKEN):
-        logging.debug(f"trying [SHA]-pattern: {full_image_pattern=} -> {image=}")
+        logging.debug(f"trying [SHA]-pattern: {full_image_pattern=} -> {line_image=}")
         # Example Matches:
         # "feature-branch-[SHA]" -> Matches "feature-branch-abc123"
         # "feature-branch-[SHA]" -> Does NOT match "feature-branch-xyz-abc123"
 
         # w/o SHA_TOKEN suffix (ex: feature-branch-)
         base = full_image_pattern[: -len(SHA_TOKEN)]
-        if not image.startswith(base):
+        if not line_image.startswith(base):
             logging.debug(f"-> no match (does not start with {base=})")
             return False
 
         # the suffix of an actual image (ex: abc123 -> True; xyz-abc123 -> False)
-        potential_sha = image[len(base) :]
+        potential_sha = line_image[len(base) :]
         if SHA_PATTERN.fullmatch(potential_sha):
             logging.debug(f"-> matched!")
             return True
@@ -45,8 +45,10 @@ def _matches_pattern(full_image_pattern: str, image: str) -> bool:
 
     # Exact match case
     else:
-        logging.debug(f"trying exact-name match: {full_image_pattern=} -> {image=}")
-        if image == full_image_pattern:
+        logging.debug(
+            f"trying exact-name match: {full_image_pattern=} -> {line_image=}"
+        )
+        if line_image == full_image_pattern:
             logging.debug(f"-> matched!")
             return True
         else:
@@ -54,13 +56,11 @@ def _matches_pattern(full_image_pattern: str, image: str) -> bool:
             return False
 
 
-def _get_image(line: str) -> str:
+def _get_line_image(line: str) -> str:
     try:
-        image = line.split()[-1]
+        return line.split()[-1]
     except IndexError:
-        image = ""
-    logging.debug(f"image: {line=} -> {image=}")
-    return image
+        return ""
 
 
 def main() -> None:
@@ -92,8 +92,7 @@ def main() -> None:
     # Modify lines that match the pattern
     full_image_pattern = str(args.dest_dir / args.image_nametag_pattern)
     out_lines = [
-        f"-{ln}" if _matches_pattern(full_image_pattern, _get_image(ln)) else ln
-        for ln in in_lines
+        f"-{ln}" if _matches_pattern(full_image_pattern, ln) else ln for ln in in_lines
     ]
 
     # log changed lines

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,15 @@
 """Utility functions."""
 
+import dataclasses
 import re
+
+
+@dataclasses.dataclass
+class ImageParsed:
+    """Parts of the image uri/name/tag"""
+
+    uri: str
+    nametag: str
 
 
 _IMAGE_NAME = r"[a-z0-9._-]+"
@@ -11,11 +20,14 @@ IMAGE_NAMETAG_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_VERBATIM}$")
 IMAGE_NAMETAG_PATTERN_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_PATTERN}$")
 
 
-def valid_image_nametag(image_nametag: str) -> str:
-    """Return `image_nametag` if it is a valid image name w/ tag.`"""
-    if not IMAGE_NAMETAG_RE.fullmatch(image_nametag):
-        raise ValueError(f"Invalid image name/tag: {image_nametag}")
-    return image_nametag
+def parse_image_uri(image_uri: str) -> ImageParsed:
+    """Return `ImageParsed` obj if it is a valid image uri w/ name and tag."""
+
+    nametag = image_uri.split("/")[-1]
+    if not IMAGE_NAMETAG_RE.fullmatch(nametag):
+        raise ValueError(f"Invalid image name/tag ({nametag}) for uri: {image_uri}")
+
+    return ImageParsed(image_uri, nametag)
 
 
 def valid_image_nametag_pattern(image_nametag_pattern: str) -> str:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,25 @@
+"""Utility functions."""
+
+import re
+
+
+_IMAGE_NAME = r"[a-z0-9._-]+"
+_TAG_VERBATIM = r"[a-zA-Z0-9._-]+"
+_TAG_PATTERN = r"[a-zA-Z0-9._\-\[\]]+"  # this one allows [ and ]
+
+IMAGE_TAG_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_VERBATIM}$")
+IMAGE_TAG_PATTERN_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_PATTERN}$")
+
+
+def valid_image_tag(image_tag: str) -> str:
+    """Return `image_tag` if it is a valid image tag.`"""
+    if not IMAGE_TAG_RE.fullmatch(image_tag):
+        raise ValueError(f"Invalid image tag: {image_tag}")
+    return image_tag
+
+
+def valid_image_tag_pattern(image_tag_pattern: str) -> str:
+    """Return `image_tag_pattern` if it is a valid image tag (verbatim or pattern)."""
+    if not IMAGE_TAG_PATTERN_RE.fullmatch(image_tag_pattern):
+        raise ValueError(f"Invalid image tag or tag pattern: {image_tag_pattern}")
+    return image_tag_pattern

--- a/utils.py
+++ b/utils.py
@@ -7,19 +7,19 @@ _IMAGE_NAME = r"[a-z0-9._-]+"
 _TAG_VERBATIM = r"[a-zA-Z0-9._-]+"
 _TAG_PATTERN = r"[a-zA-Z0-9._\-\[\]]+"  # this one allows [ and ]
 
-IMAGE_TAG_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_VERBATIM}$")
-IMAGE_TAG_PATTERN_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_PATTERN}$")
+IMAGE_NAMETAG_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_VERBATIM}$")
+IMAGE_NAMETAG_PATTERN_RE = re.compile(rf"^{_IMAGE_NAME}:{_TAG_PATTERN}$")
 
 
-def valid_image_tag(image_tag: str) -> str:
-    """Return `image_tag` if it is a valid image tag.`"""
-    if not IMAGE_TAG_RE.fullmatch(image_tag):
-        raise ValueError(f"Invalid image tag: {image_tag}")
-    return image_tag
+def valid_image_nametag(image_nametag: str) -> str:
+    """Return `image_nametag` if it is a valid image name w/ tag.`"""
+    if not IMAGE_NAMETAG_RE.fullmatch(image_nametag):
+        raise ValueError(f"Invalid image name/tag: {image_nametag}")
+    return image_nametag
 
 
-def valid_image_tag_pattern(image_tag_pattern: str) -> str:
-    """Return `image_tag_pattern` if it is a valid image tag (verbatim or pattern)."""
-    if not IMAGE_TAG_PATTERN_RE.fullmatch(image_tag_pattern):
-        raise ValueError(f"Invalid image tag or tag pattern: {image_tag_pattern}")
-    return image_tag_pattern
+def valid_image_nametag_pattern(image_nametag_pattern: str) -> str:
+    """Return `image_nametag_pattern` if it is a valid image tag (verbatim or pattern)."""
+    if not IMAGE_NAMETAG_PATTERN_RE.fullmatch(image_nametag_pattern):
+        raise ValueError(f"Invalid image tag or tag pattern: {image_nametag_pattern}")
+    return image_nametag_pattern

--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,11 @@ class ImageParsed:
     nametag: str
 
 
-_IMAGE_NAME = r"[a-z0-9._-]+"
+# ex:
+#   skymap_scanner:3.0.34
+#   iceprod@sha256:eb44b05c3890e85e0dd862e7e94d7cbc72fdb8c11ffec956e559058bac7efc3a
+#   skymap_scanner:binning-[SHA]
+_IMAGE_NAME = r"[a-z0-9._-@]+"  # note: '@' simply allows a digest to be included
 _TAG_VERBATIM = r"[a-zA-Z0-9._-]+"
 _TAG_PATTERN = r"[a-zA-Z0-9._\-\[\]]+"  # this one allows [ and ]
 


### PR DESCRIPTION
From now on, user workflows will need to provide the full* destination dir path in `dest_dir`. For example: `realtime` for `realtime/skymap_scanner:3.0.29`, `ewms/observation-management-service` for `ewms/observation-management-service/ewms-pilot:0.22.3`

WYSIWYG

_*"full" meaning relative to `/cvmfs/icecube.opensciencegrid.org/containers/`_

This also resolves a long-standing issue that prevented the removal of non-DockerHub-based images, as described in #7.

**Other changes:**
- adds support for removing multiple tag patterns
- uses an env var for the docker-images file

closes #7 